### PR TITLE
Meteor generates URL without & at the end

### DIFF
--- a/dropbox_client.js
+++ b/dropbox_client.js
@@ -28,7 +28,7 @@ DropboxOAuth.requestCredential = function (options, callback) {
         '&client_id=' + config.clientId +
         '&redirect_uri=' + OAuth._redirectUri('dropbox', config, {}, {secure: true}) +
         '&state=' + OAuth._stateParam(loginStyle, credentialToken);
-  loginUrl = loginUrl.replace('?close&', '?close=true&');
+  loginUrl = loginUrl.replace('?close', '?close=true');
 
   OAuth.launchLogin({
     loginService: "dropbox",


### PR DESCRIPTION
The replace will fail when Meteor returns: http://localhost:3000/_oauth/dropbox?close. Because this solution just uses string replacement this will generate issues because it will not replace the string.

This leads to Dropbox not accepting the request because of an invalid redirector.

Could not find any tests to modify. If there are any let me know.
